### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,23 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/DerThorsten/jupyterlite_xeus_wren/compare/first-commit...6c1c831b3ece43e40c9725519f2453e8e7efc431))
+
+### Maintenance and upkeep improvements
+
+- Ci [#3](https://github.com/DerThorsten/jupyterlite_xeus_wren/pull/3) ([@DerThorsten](https://github.com/DerThorsten))
+- using pinnig in Dockerfile [#1](https://github.com/DerThorsten/jupyterlite_xeus_wren/pull/1) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Documentation improvements
+
+- Update screencast and github actions link [#4](https://github.com/DerThorsten/jupyterlite_xeus_wren/pull/4) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/DerThorsten/jupyterlite_xeus_wren/graphs/contributors?from=2021-10-07&to=2021-10-20&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3ADerThorsten%2Fjupyterlite_xeus_wren+involves%3ADerThorsten+updated%3A2021-10-07..2021-10-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3ADerThorsten%2Fjupyterlite_xeus_wren+involves%3Ajtpio+updated%3A2021-10-07..2021-10-20&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | DerThorsten/jupyterlite_xeus_wren  |
| Branch  | main  |
| Version Spec | 0.1.1 |
| Since | first-commit |