### PR TITLE
Automated Changelog Entry for 0.1.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.2
+
+([Full Changelog](https://github.com/jupyterlite/xeus-wren-kernel/compare/v0.1.1...812b17e363e3926a2f6534f580374cca6eb73f2b))
+
+### Maintenance and upkeep improvements
+
+- Update links [#7](https://github.com/jupyterlite/xeus-wren-kernel/pull/7) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- using jupyter-xeus/xeus-wren instead of DerThorsten/xeus-wren [#6](https://github.com/jupyterlite/xeus-wren-kernel/pull/6) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-wren-kernel/graphs/contributors?from=2021-10-20&to=2021-10-22&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-wren-kernel+involves%3ADerThorsten+updated%3A2021-10-20..2021-10-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-wren-kernel+involves%3Ajtpio+updated%3A2021-10-20..2021-10-22&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.1
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-wren-kernel/compare/first-commit...6c1c831b3ece43e40c9725519f2453e8e7efc431))
@@ -20,5 +40,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-wren-kernel/graphs/contributors?from=2021-10-07&to=2021-10-20&type=c))
 
 [@DerThorsten](https://github.com/search?q=repo%3ADerThorsten%2Fjupyterlite_xeus_wren+involves%3ADerThorsten+updated%3A2021-10-07..2021-10-20&type=Issues) | [@jtpio](https://github.com/search?q=repo%3ADerThorsten%2Fjupyterlite_xeus_wren+involves%3Ajtpio+updated%3A2021-10-07..2021-10-20&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.2 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-wren-kernel  |
| Branch  | main  |
| Version Spec | 0.1.2 |
| Since | v0.1.1 |