### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jupyterlite/xeus-wren-kernel/compare/v0.1.2...ebfe2958b258bd739421507078290d758b111cd5))
+
+### Merged PRs
+
+- Update to xeus-wren 0.3.3 [#9](https://github.com/jupyterlite/xeus-wren-kernel/pull/9) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-wren-kernel/graphs/contributors?from=2021-10-22&to=2022-03-17&type=c))
+
+[@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-wren-kernel+involves%3ASylvainCorlay+updated%3A2021-10-22..2022-03-17&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.2
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-wren-kernel/compare/v0.1.1...812b17e363e3926a2f6534f580374cca6eb73f2b))
@@ -19,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-wren-kernel/graphs/contributors?from=2021-10-20&to=2021-10-22&type=c))
 
 [@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-wren-kernel+involves%3ADerThorsten+updated%3A2021-10-20..2021-10-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-wren-kernel+involves%3Ajtpio+updated%3A2021-10-20..2021-10-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-wren-kernel  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since | v0.1.2 |